### PR TITLE
Add example usecase

### DIFF
--- a/pda-backend/api/user/input.py
+++ b/pda-backend/api/user/input.py
@@ -2,6 +2,7 @@ from usecases.example import ExampleUseCase
 from usecases.usecase import UseCase
 from __main__ import app
 from flask import request
+import random
 
 @app.route('/input', methods=['POST'])
 def text_input():

--- a/pda-backend/api/user/input.py
+++ b/pda-backend/api/user/input.py
@@ -1,0 +1,30 @@
+from usecases.example import ExampleUseCase
+from usecases.usecase import UseCase
+from __main__ import app
+from flask import request
+
+@app.route('/input', methods=['POST'])
+def text_input():
+    message = request.get_data(as_text=True)
+    app.logger.info("Nachricht empfangen: {}".format(message))
+
+    usecases: List[UseCase] = [ExampleUseCase()]
+    selected_usecase = None
+
+    for usecase in usecases:
+        triggers = usecase.get_triggerwords()
+        for trigger in triggers:
+            if trigger in message:
+                selected_usecase = usecase
+                continue
+
+
+    response = None
+    if selected_usecase is None:
+        response = random.choice(["I didn't understand you. Please try again"])
+    else:
+        app.logger.info("Using UseCase handler {}".format(selected_usecase))
+        response = selected_usecase.asked(message)
+
+    app.logger.info("Responding with: {}".format(response))
+    return response

--- a/pda-backend/api/user/input.py
+++ b/pda-backend/api/user/input.py
@@ -13,10 +13,9 @@ def text_input():
 
     for usecase in usecases:
         triggers = usecase.get_triggerwords()
-        for trigger in triggers:
-            if trigger in message:
-                selected_usecase = usecase
-                continue
+        if any(trigger in message for trigger in triggers):
+            selected_usecase = usecase
+            break
 
 
     response = None

--- a/pda-backend/app.py
+++ b/pda-backend/app.py
@@ -1,6 +1,5 @@
 from flask import Flask, request
 from flask_cors import CORS
-import random
 
 app = Flask(__name__)
 CORS(app)

--- a/pda-backend/app.py
+++ b/pda-backend/app.py
@@ -4,23 +4,8 @@ import random
 
 app = Flask(__name__)
 CORS(app)
-
-@app.route("/")
-def home():
-    message = "Hallo ich bin J.A.R.V.I.S."
-    print(message)
-    return message
-
-@app.route('/input', methods=['POST'])
-def text_input():
-    message = request.get_data(as_text=True)
-    responses = ["Hello, i'm J.A.R.V.I.S.",
-                 "How are you?",
-                 "What's up?",
-                 "Nice to meet you!"]
-    response = random.choice(responses)
-    app.logger.info("Nachricht empfangen: {}; responding with: {}".format(message, response))
-    return response
+# das sagt, dass die api routes aus api/input.py benutzt werden sollen
+import api.user.input
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8000, debug=True)

--- a/pda-backend/usecases/example.py
+++ b/pda-backend/usecases/example.py
@@ -1,0 +1,16 @@
+from usecases.usecase import UseCase
+
+class ExampleUseCase(UseCase):
+    def get_triggerwords(self) -> list[str]:
+        return ["example"]
+
+    def trigger(sefl) -> str:
+        # hier kommt das periodische checken für proaktive Dinge rein.
+        
+        # hier muss jeder trigger noch den nächsten run schedulen. Aktuell geht das nicht, wir haben ja noch keinen scheduler.
+
+        # hier kommt der text der an den user gelesen wird hin
+        return "Periodic trigger of the example usecase"
+
+    def asked(sefl, input: str) -> str:
+        return "You said: " + input

--- a/pda-backend/usecases/usecase.py
+++ b/pda-backend/usecases/usecase.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+import types
+
+class UseCase(ABC):
+
+    @abstractmethod
+    def get_triggerwords(self) -> list[str]:
+        """Get the triggerwords triggering the usecase when asked by the user
+
+        Returns:
+            List[str]: list of triggerwords
+        """
+        pass
+
+    @abstractmethod
+    def trigger(self) -> str:
+        """This method gets called by the scheduler when 
+
+        Returns:
+            str: output text read to the user
+        """
+        pass
+
+    @abstractmethod
+    def asked(self, input: str) -> str:
+        """Method getting called when the user mentioned one of the triggerwords
+
+        Args:
+            input (str): full text input from the user
+
+        Returns:
+            str: text to read back to the user
+        """
+        pass


### PR DESCRIPTION
Hier mal ein Beispiel usecase der einfach nur den text wiederholt, wenn der input example beinhaltet.
Ein **Beispielinput** der geht ist:
```
I'm great cause this example works
```
**Output**:
```
You said: I'm great cause this example works
```

Könnt einfach die example.py Datei kopieren und nen eigenen usecase schreiben. Damit der funktioniert muss der in api/user/input.py importiert werden und in den array `usecases` hinzugefügt werden (siehe example)

~~Idk was passiert wenn ein keyword von mehreren usecases registriert wird oder keywords von mehreren usecases in der eingäbe gefunden werden.~~

Ich glaube das was in der liste als erstes kommt, hat Priorität mit den keywords.