### PR TITLE
Use home address in fuel usecase

### DIFF
--- a/pda-backend/requirements-maker.py
+++ b/pda-backend/requirements-maker.py
@@ -1,5 +1,0 @@
-import subprocess
-
-# Erstellen Sie eine requirements.txt-Datei
-with open("requirements.txt", "w") as f:
-    subprocess.call(["pip", "freeze"], stdout=f)

--- a/pda-backend/requirements.txt
+++ b/pda-backend/requirements.txt
@@ -11,3 +11,4 @@ pytest-mock
 pytest-func-cov
 apscheduler
 kink
+geopy

--- a/pda-backend/services/geolocation.py
+++ b/pda-backend/services/geolocation.py
@@ -1,0 +1,14 @@
+import geopy
+
+def get_location_from_address(address: str) -> tuple[float, float]:
+	"""Get the location of a given address
+
+	Args:
+		address (str): address to get the location for
+
+	Returns:
+		tuple[float, float]: the latitude and longitude of the given address
+	"""
+	geolocator = geopy.geocoders.Nominatim(user_agent="PersonalDigitalAssistant DHBW Stuttgart 20ITA")
+	location = geolocator.geocode(address)
+	return location.latitude, location.longitude

--- a/pda-backend/settings.json
+++ b/pda-backend/settings.json
@@ -14,8 +14,6 @@
     },
     "sparen": {
         "sprit": {
-            "lat": 48.83421132375812,
-            "lng": 9.152560823835184,
             "preisschwelle": 1.299,
             "radius": 5,
             "typ": "e10"

--- a/pda-backend/tests/services/geolocation_test.py
+++ b/pda-backend/tests/services/geolocation_test.py
@@ -1,0 +1,12 @@
+import services.geolocation as geolocation
+
+
+def tests_geolocation():
+	lat, lng = geolocation.get_location_from_address("Porscheplatz 1, Stuttgart, Germany")
+	assert type(lat) == float
+	assert type(lng) == float
+	#48.834909589444884, 9.152177970447948
+	assert lat > 48.833
+	assert lat < 48.835
+	assert lng > 9.152
+	assert lng < 9.153

--- a/pda-backend/usecases/sparsupport.py
+++ b/pda-backend/usecases/sparsupport.py
@@ -3,6 +3,7 @@ from services.tankerkoenig import get_fuelprice
 from services.stocks import get_stock_price
 from scheduler import Scheduler
 from settings_manager import SettingsManager
+import services.geolocation as geolocation
 from kink import inject
 
 GENERAL_TRIGGERS = ["save", "money", "cheap", "cheaply"]
@@ -34,7 +35,9 @@ class SparenUseCase(UseCase):
 
 	def current_fuelprice(self) -> str:
 		settings = self.get_settings()["sprit"]
-		location, price = get_fuelprice(settings["typ"], settings["lat"], settings["lng"], settings["radius"])
+		home_address = self.settings.get_setting_by_name("goodMorning")["homeAddress"]
+		lat, lng = geolocation.get_location_from_address(home_address)
+		location, price = get_fuelprice(settings["typ"], lat, lng, settings["radius"])
 		return "The currently lowest {} fuel price is {:.3f}€ at {}.".format(settings["typ"], price, location)
 
 	def current_stockprice(self) -> str:


### PR DESCRIPTION
address from guten morgen usecase settings instead of separate lat and long